### PR TITLE
fix: use brew python for hypr-pop-windows-gen, install pyyaml via fir…

### DIFF
--- a/files/system/usr/bin/hypr-pop-windows-gen
+++ b/files/system/usr/bin/hypr-pop-windows-gen
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/home/linuxbrew/.linuxbrew/bin/python3
 """Generate ~/.config/hypr/pop-windows.conf from YAML sources.
 
 Reads /usr/share/tarion/hypr/pop-windows.yaml (distro defaults) and
@@ -26,7 +26,7 @@ def load_yaml(path):
     try:
         import yaml
     except ImportError:
-        print("Error: python3-pyyaml is required", file=sys.stderr)
+        print("Error: pyyaml is required — run: /home/linuxbrew/.linuxbrew/bin/pip3 install pyyaml", file=sys.stderr)
         sys.exit(1)
 
     if not os.path.exists(path):

--- a/files/system/usr/bin/tarion-firstboot
+++ b/files/system/usr/bin/tarion-firstboot
@@ -41,6 +41,11 @@ if [[ "$(_state_get greeter_sync)" != "true" ]]; then
     fi
 fi
 
+# Task: install pyyaml for brew python (required by hypr-pop-windows-gen)
+if [[ "$(_state_get pip_pyyaml)" != "true" ]]; then
+    if /home/linuxbrew/.linuxbrew/bin/pip3 install --quiet pyyaml; then _state_set pip_pyyaml; fi
+fi
+
 # Task: install DankKDEConnect plugin
 if [[ "$(_state_get dms_plugin_kdeconnect)" != "true" ]]; then
     if command -v dms &>/dev/null; then

--- a/files/system/usr/lib/systemd/user/hypr-pop-windows.service
+++ b/files/system/usr/lib/systemd/user/hypr-pop-windows.service
@@ -1,10 +1,11 @@
 [Unit]
 Description=Generate Hyprland pop window rules
-After=graphical-session.target
+After=tarion-firstboot.service
 
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/hypr-pop-windows-gen
+RemainAfterExit=yes
 
 [Install]
-WantedBy=graphical-session.target
+WantedBy=graphical-session-pre.target

--- a/recipes/stages/01-desktop-core.yml
+++ b/recipes/stages/01-desktop-core.yml
@@ -33,4 +33,3 @@ modules:
         - uwsm
         - xdg-terminal-exec
         - hyprsysteminfo
-        - python3-pyyaml


### PR DESCRIPTION
…stboot

- Switch shebang to /home/linuxbrew/.linuxbrew/bin/python3
- Install pyyaml via brew pip3 in tarion-firstboot (idempotent)
- Fix service ordering: WantedBy=graphical-session-pre.target so pop-windows.conf is generated before Hyprland reads its config
- Remove python3-pyyaml DNF package from recipe